### PR TITLE
Handle NoBrokersAvailable in metric collector

### DIFF
--- a/backend-server/app/domain/services/metric_service.py
+++ b/backend-server/app/domain/services/metric_service.py
@@ -2,15 +2,32 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime
+from functools import lru_cache
+
+from kafka.errors import NoBrokersAvailable
 
 from app.api.web_socket import connection_manager
 from app.domain.models.metrics import ClusterMetrics
 from app.infra.kafka.admin import KafkaAdminFacade
 
 
+logger = logging.getLogger(__name__)
+
+
+@lru_cache
+def _get_admin(bootstrap_servers: str) -> KafkaAdminFacade:
+    """Return a cached Kafka admin facade for the cluster."""
+    return KafkaAdminFacade(bootstrap_servers)
+
+
 async def _collect(bootstrap_servers: str, sec: float) -> None:
-    admin = KafkaAdminFacade(bootstrap_servers)
+    try:
+        admin = _get_admin(bootstrap_servers)
+    except NoBrokersAvailable:
+        logger.warning("Kafka brokers unavailable; metrics collection disabled.")
+        return
     while True:
         # Simplest KPI-only snapshot
         cluster_meta = admin._client.describe_cluster()
@@ -27,4 +44,9 @@ async def _collect(bootstrap_servers: str, sec: float) -> None:
 
 def start_metric_collector(bootstrap_servers: str, interval: float) -> None:
     """Schedule async task from FastAPI startup event."""
+    try:
+        _get_admin(bootstrap_servers)
+    except NoBrokersAvailable:
+        logger.warning("Kafka brokers unavailable; metric collector not started.")
+        return
     asyncio.get_event_loop().create_task(_collect(bootstrap_servers, interval))


### PR DESCRIPTION
## Summary
- Guard Kafka metric collector against missing brokers by catching `NoBrokersAvailable` on admin facade creation.
- Cache Kafka admin facade instances and start metric collection only when initialization succeeds.

## Testing
- `cd backend-server && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689005090cc08322987ae8899a3e8929